### PR TITLE
Fixed needing to disable/re-enable interrupts for the rain gauge by chan...

### DIFF
--- a/Weatherstation_nonwireless/Weatherstation_nonwireless.ino
+++ b/Weatherstation_nonwireless/Weatherstation_nonwireless.ino
@@ -51,7 +51,7 @@ void setup() {
      digitalWrite(ANEMOMETER, HIGH);
      pinMode(RAINGAUGE, INPUT);
      digitalWrite(RAINGAUGE, HIGH);
-     attachInterrupt(1,CountRain, LOW);
+     attachInterrupt(1,CountRain, FALLING);
      dht.begin();
      pressure.begin();
      
@@ -59,7 +59,6 @@ void setup() {
 }
 
 void loop() {
-  attachInterrupt(1,CountRain, LOW);
   broadcast();
   delay(60000);
   
@@ -86,7 +85,6 @@ void broadcast() {
 
 void CountRain() {
   raintips++;
-  detachInterrupt(1);
 }
 
 void calcWindDir() {


### PR DESCRIPTION
...ging the IRQ condition from 'LOW' to 'FALLING'. When LOW IRQ condition is continuously met (signal is low) until signal returns high, however when FALLING condition is only met once (falling edge) per pulse.

In the unlikely event another valid signal occurs before the previous interrupt routine has completed, the interrupt will correctly execute again afterwards instead of being ignored.
